### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 An MCP server for managing and navigating nf-core pipeline repositories.
 
+<a href="https://glama.ai/mcp/servers/@wjlim/nf-core_mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@wjlim/nf-core_mcp/badge" alt="nf-core Server MCP server" />
+</a>
+
 ## Features
 
 - List local nf-core repositories (rnaseq, sarek, modules, tools)


### PR DESCRIPTION
This PR adds a badge for the [nf-core MCP Server](https://glama.ai/mcp/servers/@wjlim/nf-core_mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@wjlim/nf-core_mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@wjlim/nf-core_mcp/badge" alt="nf-core Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.